### PR TITLE
Created events for MedievalFactions.

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/CreateCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/CreateCommand.java
@@ -3,8 +3,10 @@ package dansplugins.factionsystem.commands;
 import dansplugins.factionsystem.LocaleManager;
 import dansplugins.factionsystem.MedievalFactions;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.events.FactionCreateEvent;
 import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.utils.ArgumentParser;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -45,10 +47,13 @@ public class CreateCommand {
         }
 
         Faction temp = new Faction(name, player.getUniqueId(), MedievalFactions.getInstance().getConfig().getInt("initialMaxPowerLevel"));
-        PersistentData.getInstance().getFactions().add(temp);
-        PersistentData.getInstance().getFactions().get(PersistentData.getInstance().getFactions().size() - 1).addMember(player.getUniqueId(), PersistentData.getInstance().getPlayersPowerRecord(player.getUniqueId()).getPowerLevel());
-        player.sendMessage(ChatColor.AQUA + LocaleManager.getInstance().getText("FactionCreated"));
-
+        temp.addMember(player.getUniqueId(), PersistentData.getInstance().getPlayersPowerRecord(player.getUniqueId()).getPowerLevel());
+        FactionCreateEvent createEvent = new FactionCreateEvent(temp, player);
+        Bukkit.getPluginManager().callEvent(createEvent);
+        if (!createEvent.isCancelled()) {
+            PersistentData.getInstance().getFactions().add(temp);
+            player.sendMessage(ChatColor.AQUA + LocaleManager.getInstance().getText("FactionCreated"));
+        }
         return true;
     }
 }

--- a/src/main/java/dansplugins/factionsystem/commands/JoinCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/JoinCommand.java
@@ -3,8 +3,10 @@ package dansplugins.factionsystem.commands;
 import dansplugins.factionsystem.LocaleManager;
 import dansplugins.factionsystem.Messenger;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.events.FactionJoinEvent;
 import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.utils.ArgumentParser;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -27,6 +29,12 @@ public class JoinCommand {
 
                                 // join if player isn't in a faction already
                                 if (!(PersistentData.getInstance().isInFaction(player.getUniqueId()))) {
+                                    FactionJoinEvent event = new FactionJoinEvent(faction, player);
+                                    Bukkit.getPluginManager().callEvent(event);
+                                    if (event.isCancelled()) {
+                                        // TODO Add a message (maybe)
+                                        continue; // Added because idk why this is in a loop.
+                                    }
                                     faction.addMember(player.getUniqueId(), PersistentData.getInstance().getPlayersPowerRecord(player.getUniqueId()).getPowerLevel());
                                     faction.uninvite(player.getUniqueId());
                                     try {

--- a/src/main/java/dansplugins/factionsystem/commands/KickCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/KickCommand.java
@@ -4,6 +4,7 @@ import dansplugins.factionsystem.LocaleManager;
 import dansplugins.factionsystem.Messenger;
 import dansplugins.factionsystem.data.EphemeralData;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.events.FactionKickEvent;
 import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.utils.UUIDChecker;
 import org.bukkit.Bukkit;
@@ -29,6 +30,17 @@ public class KickCommand {
                             if (faction.isMember(playerUUID)) {
                                 if (!(args[1].equalsIgnoreCase(player.getName()))) {
                                     if (!(playerUUID.equals(faction.getOwner()))) {
+
+                                        FactionKickEvent event = new FactionKickEvent(
+                                                faction,
+                                                Bukkit.getPlayer(playerUUID),
+                                                player
+                                        );
+                                        Bukkit.getPluginManager().callEvent(event);
+                                        if (event.isCancelled()) {
+                                            // TODO Add a message (maybe).
+                                            continue; // Loop mechanism.
+                                        }
 
                                         if (faction.isOfficer(playerUUID)) {
                                             faction.removeOfficer(playerUUID);

--- a/src/main/java/dansplugins/factionsystem/commands/LeaveCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/LeaveCommand.java
@@ -6,7 +6,9 @@ import dansplugins.factionsystem.LocaleManager;
 import dansplugins.factionsystem.Messenger;
 import dansplugins.factionsystem.data.EphemeralData;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.events.FactionLeaveEvent;
 import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -25,6 +27,15 @@ public class LeaveCommand {
                                 // is faction empty?
                                 if (PersistentData.getInstance().getFactions().get(i).getPopulation() == 1) {
                                     // able to leave
+                                    FactionLeaveEvent event = new FactionLeaveEvent(
+                                            PersistentData.getInstance().getFactions().get(i),
+                                            player
+                                    );
+                                    Bukkit.getPluginManager().callEvent(event);
+                                    if (event.isCancelled()) {
+                                        // TODO Add a message (maybe).
+                                        continue; // Added because of loop mechanism.
+                                    }
 
                                     if (PersistentData.getInstance().getFactions().get(i).isOfficer(player.getUniqueId())) {
                                         PersistentData.getInstance().getFactions().get(i).removeOfficer(player.getUniqueId());

--- a/src/main/java/dansplugins/factionsystem/commands/RenameCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/RenameCommand.java
@@ -3,10 +3,12 @@ package dansplugins.factionsystem.commands;
 import dansplugins.factionsystem.LocaleManager;
 import dansplugins.factionsystem.StorageManager;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.events.FactionRenameEvent;
 import dansplugins.factionsystem.objects.ClaimedChunk;
 import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.objects.LockedBlock;
 import dansplugins.factionsystem.utils.ArgumentParser;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -49,6 +51,13 @@ public class RenameCommand {
 
         if (PersistentData.getInstance().getFaction(newName) != null) {
             player.sendMessage(ChatColor.RED + LocaleManager.getInstance().getText("FactionAlreadyExists"));
+            return false;
+        }
+
+        FactionRenameEvent renameEvent = new FactionRenameEvent(playersFaction, oldName, newName);
+        Bukkit.getPluginManager().callEvent(renameEvent);
+        if (renameEvent.isCancelled()) {
+            // TODO Add a message here (maybe).
             return false;
         }
 

--- a/src/main/java/dansplugins/factionsystem/events/FactionClaimEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionClaimEvent.java
@@ -1,0 +1,45 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.events.abs.FactionEvent;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.Chunk;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionClaimEvent extends FactionEvent implements Cancellable {
+
+    // Variables.
+    private boolean cancelled = false;
+    private final Chunk chunk;
+
+    /**
+     * Constructor to initialise a FactionClaimEvent.
+     * @param faction related to the claim.
+     * @param player who claimed for the Faction.
+     * @param chunk to be claimed.
+     */
+    public FactionClaimEvent(Faction faction, Player player, Chunk chunk) {
+        super(faction, player);
+        this.chunk = chunk;
+    }
+
+    // Getters.
+    public Chunk getChunk() {
+        return chunk;
+    }
+
+    // Bukkit Cancellable methodology.
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionCreateEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionCreateEvent.java
@@ -1,0 +1,38 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.events.abs.FactionEvent;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionCreateEvent extends FactionEvent implements Cancellable {
+
+    // Variables.
+    private boolean cancelled = false;
+
+    /**
+     * Constructor to initialise a FactionCreateEvent.
+     * <p>
+     *     This event is called when a Player creates a Faction.
+     * </p>
+     * @param faction being created.
+     * @param player who created it.
+     */
+    public FactionCreateEvent(Faction faction, Player player) {
+        super(faction, player);
+    }
+
+    // Cancellable methodology.
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionDisbandEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionDisbandEvent.java
@@ -1,0 +1,39 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.events.abs.FactionEvent;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionDisbandEvent extends FactionEvent implements Cancellable {
+
+    // Variables.
+    private boolean cancelled = false;
+
+    /**
+     * Constructor to initialise a FactionDisbandEvent.
+     * <p>
+     *     This event is called when a player disbands a Faction.
+     * </p>
+     * @param faction disbanded
+     * @param player who disbanded the Faction.
+     */
+    public FactionDisbandEvent(Faction faction, OfflinePlayer player) {
+        super(faction, player);
+    }
+
+    // Bukkit Cancellable methodology.
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionJoinEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionJoinEvent.java
@@ -1,0 +1,39 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.events.abs.FactionEvent;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionJoinEvent extends FactionEvent implements Cancellable {
+
+    // Variables.
+    private boolean cancelled = false;
+
+    /**
+     * Constructor to initialise a FactionJoinEvent
+     * <p>
+     *     This event is called when a Player joins a Faction.
+     * </p>
+     * @param faction which was joined.
+     * @param player who joined.
+     */
+    public FactionJoinEvent(Faction faction, OfflinePlayer player) {
+        super(faction, player);
+    }
+
+    // Bukkit Cancellable methodology.
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionKickEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionKickEvent.java
@@ -1,0 +1,34 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.OfflinePlayer;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionKickEvent extends FactionLeaveEvent {
+
+    // Variables.
+    private final OfflinePlayer kicker;
+
+    /**
+     * Constructor to initialise a FactionKickEvent.
+     * <p>
+     *     This event is called when a Player is kicked from a Faction.
+     * </p>
+     *
+     * @param faction which the player was kicked from.
+     * @param player  who was kicked.
+     * @param kicker who kicked the player.
+     */
+    public FactionKickEvent(Faction faction, OfflinePlayer player, OfflinePlayer kicker) {
+        super(faction, player);
+        this.kicker = kicker;
+    }
+
+    // Getters.
+    public OfflinePlayer getKicker() {
+        return kicker;
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionLeaveEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionLeaveEvent.java
@@ -1,0 +1,39 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.events.abs.FactionEvent;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionLeaveEvent extends FactionEvent implements Cancellable {
+
+    // Variables.
+    private boolean cancelled = false;
+
+    /**
+     * Constructor to initialise a FactionLeaveEvent.
+     * <p>
+     *     This event is called when a Player leaves a Faction.
+     * </p>
+     * @param faction which was left.
+     * @param player who left.
+     */
+    public FactionLeaveEvent(Faction faction, OfflinePlayer player) {
+        super(faction, player);
+    }
+
+    // Bukkit Cancellable methodology.
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+    
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionRenameEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionRenameEvent.java
@@ -1,0 +1,50 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.events.abs.FactionEvent;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.event.Cancellable;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionRenameEvent extends FactionEvent implements Cancellable {
+
+    // Variables.
+    private final String current, proposed;
+    private boolean cancelled = false;
+
+    /**
+     * Constructor to initialise a FactionRenameEvent.
+     * <p>
+     *     This event is called when a Faction is renamed from 'x' to 'y'.
+     * </p>
+     * @param faction being renamed.
+     * @param currentName of the Faction.
+     * @param proposedName or new name of the Faction.
+     */
+    public FactionRenameEvent(Faction faction, String currentName, String proposedName) {
+        super(faction);
+        this.current = currentName;
+        this.proposed = proposedName;
+    }
+
+    // Getters.
+    public String getCurrentName(){
+        return current;
+    }
+
+    public String getProposedName() {
+        return proposed;
+    }
+
+    // Bukkit Cancellable methodology.
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        this.cancelled = b;
+    }
+}

--- a/src/main/java/dansplugins/factionsystem/events/FactionUnclaimEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/FactionUnclaimEvent.java
@@ -1,0 +1,23 @@
+package dansplugins.factionsystem.events;
+
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.Chunk;
+import org.bukkit.entity.Player;
+
+/**
+ * @author C A L L U M#4160
+ */
+public class FactionUnclaimEvent extends FactionClaimEvent {
+
+    /**
+     * Constructor to initialise a FactionUnclaimEvent.
+     *
+     * @param faction related to the claim.
+     * @param player  who unclaimed for the Faction.
+     * @param chunk   to be unclaimed.
+     */
+    public FactionUnclaimEvent(Faction faction, Player player, Chunk chunk) {
+        super(faction, player, chunk);
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/events/abs/FactionEvent.java
+++ b/src/main/java/dansplugins/factionsystem/events/abs/FactionEvent.java
@@ -1,0 +1,56 @@
+package dansplugins.factionsystem.events.abs;
+
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * @author C A L L U M#4160
+ */
+public abstract class FactionEvent extends Event {
+
+    // Constants.
+    private static final HandlerList handlers = new HandlerList();
+
+    // Variables.
+    private final Faction faction;
+    private OfflinePlayer offlinePlayer = null;
+
+    /**
+     * Constructor for a FactionEvent with a reference to a Faction.
+     * @param faction related to the event.
+     */
+    public FactionEvent(Faction faction) {
+        this.faction = faction;
+    }
+
+    /**
+     * Constructor for a FactionEvent with a reference to both a Faction and player.
+     * @param faction related to the event.
+     * @param player related to the event.
+     */
+    public FactionEvent(Faction faction, OfflinePlayer player) {
+        this.faction = faction;
+        this.offlinePlayer = player;
+    }
+
+    // Getters.
+    public Faction getFaction() {
+        return faction;
+    }
+
+    public OfflinePlayer getOfflinePlayer() {
+        return offlinePlayer;
+    }
+
+    // Bukkit Event API requirements.
+    public HandlerList getHandlers() {
+        return FactionEvent.handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+}


### PR DESCRIPTION
FactionEvent (Abstract Superclass).
FactionClaimEvent, FactionUnclaimEvent, FactionCreateEvent, FactionDisbandEvent, FactionJoinEvent, FactionLeaveEvent, FactionKickEvent and FactionRenameEvent added.

Messages should still be added through translation keys.
(All locations of messages can be found on the TODO page for IDEs such as IntelliJ).