### PR TITLE
Faction Flags Feature (includes 4 new faction flags)

### DIFF
--- a/src/main/java/dansplugins/factionsystem/CommandInterpreter.java
+++ b/src/main/java/dansplugins/factionsystem/CommandInterpreter.java
@@ -21,7 +21,7 @@ public class CommandInterpreter {
                 new BypassCommand(), new ChatCommand(), new CheckAccessCommand(), new CheckClaimCommand(),
                 new ClaimCommand(), new ConfigCommand(), new CreateCommand(), new DeclareIndependenceCommand(),
                 new DeclareWarCommand(), new DemoteCommand(), new DescCommand(), new DisbandCommand(),
-                new DuelCommand(), new EditLawCommand(), new ForceCommand(), new GateCommand(),
+                new DuelCommand(), new EditLawCommand(), new FlagsCommand(), new ForceCommand(), new GateCommand(),
                 new GrantAccessCommand(), new GrantIndependenceCommand(), new HelpCommand(), new HomeCommand(),
                 new InfoCommand(), new InviteCommand(), new InvokeCommand(), new JoinCommand(), new KickCommand(),
                 new LawsCommand(), new LeaveCommand(), new ListCommand(), new LockCommand(), new MakePeaceCommand(),

--- a/src/main/java/dansplugins/factionsystem/MedievalFactionsAPI.java
+++ b/src/main/java/dansplugins/factionsystem/MedievalFactionsAPI.java
@@ -5,6 +5,7 @@ import dansplugins.factionsystem.data.PersistentData;
 import dansplugins.factionsystem.managers.*;
 import dansplugins.factionsystem.utils.ArgumentParser;
 import dansplugins.factionsystem.utils.BlockChecker;
+import dansplugins.factionsystem.utils.InteractionAccessChecker;
 import dansplugins.factionsystem.utils.UUIDChecker;
 
 import java.util.UUID;
@@ -75,6 +76,10 @@ public class MedievalFactionsAPI {
 
     public GateManager getGateManager() {
         return GateManager.getInstance();
+    }
+
+    public InteractionAccessChecker getInteractionAccessChecker() {
+        return InteractionAccessChecker.getInstance();
     }
 
     // specific methods

--- a/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
@@ -32,9 +32,16 @@ public class ClaimCommand extends SubCommand {
         }
         if (args.length != 0) {
             int depth = getIntSafe(args[0], -1);
-            if (depth <= 0) player.sendMessage(translate("&c" + getText("UsageClaimRadius")));
-            else chunks.radiusClaimAtLocation(depth, player, player.getLocation(), faction);
-        } else chunks.claimChunkAtLocation(player, player.getLocation(), faction);
+            if (depth <= 0) {
+                player.sendMessage(translate("&c" + getText("UsageClaimRadius")));
+            }
+            else {
+                chunks.radiusClaimAtLocation(depth, player, player.getLocation(), faction);
+            }
+        }
+        else {
+            chunks.claimChunkAtLocation(player, player.getLocation(), faction);
+        }
         dynmap.updateClaims();
     }
 

--- a/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
@@ -22,10 +22,9 @@ public class ClaimCommand extends SubCommand {
      */
     @Override
     public void execute(Player player, String[] args, String key) {
-        Faction playersFaction = getPlayerFaction(player.getUniqueId());
-        if (playersFaction.getFlags().getFlag("mustBeOfficerToManageLand")) {
+        if (faction.getFlags().getFlag("mustBeOfficerToManageLand")) {
             // officer or owner rank required
-            if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId())) {
+            if (!faction.isOfficer(player.getUniqueId()) && !faction.isOwner(player.getUniqueId())) {
                 player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));
                 return;
             }

--- a/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
@@ -23,7 +23,7 @@ public class ClaimCommand extends SubCommand {
     @Override
     public void execute(Player player, String[] args, String key) {
         Faction playersFaction = getPlayerFaction(player.getUniqueId());
-        if (playersFaction.getFlags().getFlag("officerRankRequiredToManageLand")) {
+        if (playersFaction.getFlags().getFlag("mustBeOfficerToManageLand")) {
             // officer or owner rank required
             if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId())) {
                 player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));

--- a/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
@@ -23,7 +23,7 @@ public class ClaimCommand extends SubCommand {
     @Override
     public void execute(Player player, String[] args, String key) {
         Faction playersFaction = getPlayerFaction(player.getUniqueId());
-        if (playersFaction.getFlags().getFlag("officerRankRequiredToClaimLand")) {
+        if (playersFaction.getFlags().getFlag("officerRankRequiredToManageLand")) {
             // officer or owner rank required
             if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId())) {
                 player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));

--- a/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ClaimCommand.java
@@ -1,6 +1,7 @@
 package dansplugins.factionsystem.commands;
 
 import dansplugins.factionsystem.commands.abs.SubCommand;
+import dansplugins.factionsystem.objects.Faction;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -9,7 +10,7 @@ public class ClaimCommand extends SubCommand {
     public ClaimCommand() {
         super(new String[] {
                 "Claim", LOCALE_PREFIX + "CmdClaim"
-        }, true, true, true, false);
+        }, true, true);
     }
 
     /**
@@ -21,6 +22,14 @@ public class ClaimCommand extends SubCommand {
      */
     @Override
     public void execute(Player player, String[] args, String key) {
+        Faction playersFaction = getPlayerFaction(player.getUniqueId());
+        if (playersFaction.getFlags().getFlag("officerRankRequiredToClaimLand")) {
+            // officer or owner rank required
+            if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId())) {
+                player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));
+                return;
+            }
+        }
         if (args.length != 0) {
             int depth = getIntSafe(args[0], -1);
             if (depth <= 0) player.sendMessage(translate("&c" + getText("UsageClaimRadius")));

--- a/src/main/java/dansplugins/factionsystem/commands/FlagsCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/FlagsCommand.java
@@ -1,0 +1,70 @@
+package dansplugins.factionsystem.commands;
+
+import dansplugins.factionsystem.commands.abs.SubCommand;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class FlagsCommand extends SubCommand {
+
+    public FlagsCommand() {
+        super(new String[]{
+                "flags", LOCALE_PREFIX + "CmdFlags"
+        }, false);
+    }
+
+    /**
+     * Method to execute the command for a player.
+     *
+     * @param player who sent the command.
+     * @param args   of the command.
+     * @param key    of the sub-command (e.g. Ally).
+     */
+    @Override
+    public void execute(Player player, String[] args, String key) {
+        if (!(checkPermissions(player, "mf.flags", "mf.admin"))) { // TODO: add permission to plugin.yml
+            return;
+        }
+
+        if (args.length == 0) {
+            player.sendMessage(translate("&c" + getText("FlagsValidSubCommandsShowSet"))); // TODO: add string key/value pair
+            return;
+        }
+
+        final Faction playersFaction = getPlayerFaction(player);
+        if (playersFaction == null) {
+            player.sendMessage(translate("&c" + getText("AlertMustBeInFactionToUseCommand")));
+            return;
+        }
+
+        final boolean show = safeEquals(false, args[0], "get", "show", getText("CmdFlagsShow")); // TODO: add string key/value pair
+        final boolean set = safeEquals(false, args[0], "set", getText("CmdFlagsSet")); // TODO: add string key/value pair
+        if (show) {
+            // TODO: send list of flags
+        }
+        else if (set) {
+            if (args.length == 1) {
+                player.sendMessage(translate("&c" + getText("UsageFlagsSet"))); // TODO: add string key/value pair
+            }
+            else {
+                // TODO: set flag
+            }
+        }
+        else {
+            player.sendMessage(translate("&c" + getText("FlagsValidSubCommandsShowSet")));
+        }
+    }
+
+    /**
+     * Method to execute the command.
+     *
+     * @param sender who sent the command.
+     * @param args   of the command.
+     * @param key    of the command.
+     */
+    @Override
+    public void execute(CommandSender sender, String[] args, String key) {
+
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/commands/FlagsCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/FlagsCommand.java
@@ -10,7 +10,7 @@ public class FlagsCommand extends SubCommand {
     public FlagsCommand() {
         super(new String[]{
                 "flags", LOCALE_PREFIX + "CmdFlags"
-        }, false);
+        }, true, true, false, true);
     }
 
     /**
@@ -22,32 +22,29 @@ public class FlagsCommand extends SubCommand {
      */
     @Override
     public void execute(Player player, String[] args, String key) {
-        if (!(checkPermissions(player, "mf.flags", "mf.admin"))) { // TODO: add permission to plugin.yml
+        final String permission = "mf.flags";
+        if (!(checkPermissions(player, permission))) {
             return;
         }
 
         if (args.length == 0) {
-            player.sendMessage(translate("&c" + getText("FlagsValidSubCommandsShowSet"))); // TODO: add string key/value pair
+            player.sendMessage(translate("&c" + getText("ValidSubCommandsShowSet")));
             return;
         }
 
         final Faction playersFaction = getPlayerFaction(player);
-        if (playersFaction == null) {
-            player.sendMessage(translate("&c" + getText("AlertMustBeInFactionToUseCommand")));
-            return;
-        }
 
-        final boolean show = safeEquals(false, args[0], "get", "show", getText("CmdFlagsShow")); // TODO: add string key/value pair
-        final boolean set = safeEquals(false, args[0], "set", getText("CmdFlagsSet")); // TODO: add string key/value pair
+        final boolean show = safeEquals(false, args[0], "get", "show", getText("CmdFlagsShow"));
+        final boolean set = safeEquals(false, args[0], "set", getText("CmdFlagsSet"));
         if (show) {
-            // TODO: send list of flags
+            playersFaction.getFlags().sendFlagList(player);
         }
         else if (set) {
             if (args.length == 1) {
-                player.sendMessage(translate("&c" + getText("UsageFlagsSet"))); // TODO: add string key/value pair
+                player.sendMessage(translate("&c" + getText("UsageFlagsSet")));
             }
             else {
-                // TODO: set flag
+                playersFaction.getFlags().setFlag(args[1], args[2], player);
             }
         }
         else {

--- a/src/main/java/dansplugins/factionsystem/commands/HelpCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/HelpCommand.java
@@ -18,12 +18,15 @@ public class HelpCommand extends SubCommand {
         super(new String[] {
                 "help", LOCALE_PREFIX + "CmdHelp"
         }, false);
+
+        // there should be 9 commands per page
         helpPages.put(1, Arrays.asList("Help", "List", "Info", "Members", "Join", "Leave", "Create", "Invite", "Desc"));
-        helpPages.put(2, Arrays.asList("Kick", "Transfer", "Disband", "DeclareWar", "MakePeace", "Invoke", "Claim", "Unclaim", "Unclaimall", "CheckClaim"));
-        helpPages.put(3, Arrays.asList("Autoclaim", "Promote", "Demote", "Power", "SetHome", "Home", "Who", "Ally", "BreakAlliance"));
-        helpPages.put(4, Arrays.asList("Rename", "Lock", "Unlock", "GrantAccess", "CheckAccess", "RevokeAccess", "Laws", "AddLaw", "RemoveLaw"));
-        helpPages.put(5, Arrays.asList("EditLaw", "Chat", "Vassalize", "SwearFealty", "DeclareIndependence", "GrantIndependence", "GateCreate", "GateName", "GateList", "GateRemove", "GateCancel"));
-        helpPages.put(6, Arrays.asList("DuelChallenge", "DuelAccept", "DuelCancel", "Prefix", "Bypass", "ConfigShow", "ConfigSet", "Force", "Version", "ResetPowerLevels"));
+        helpPages.put(2, Arrays.asList("FlagsShow", "FlagsSet", "Kick", "Transfer", "Disband", "DeclareWar", "MakePeace", "Invoke", "Claim"));
+        helpPages.put(3, Arrays.asList("Unclaim", "Unclaimall", "CheckClaim", "Autoclaim", "Promote", "Demote", "Power", "SetHome", "Home"));
+        helpPages.put(4, Arrays.asList("Who", "Ally", "BreakAlliance", "Rename", "Lock", "Unlock", "GrantAccess", "CheckAccess", "RevokeAccess"));
+        helpPages.put(5, Arrays.asList("Laws", "AddLaw", "RemoveLaw", "EditLaw", "Chat", "Vassalize", "SwearFealty", "DeclareIndependence", "GrantIndependence"));
+        helpPages.put(6, Arrays.asList("GateCreate", "GateName", "GateList", "GateRemove", "GateCancel", "DuelChallenge", "DuelAccept", "DuelCancel", "Prefix"));
+        helpPages.put(7, Arrays.asList("Bypass", "ConfigShow", "ConfigSet", "Force", "Version", "ResetPowerLevels"));
     }
 
     /**

--- a/src/main/java/dansplugins/factionsystem/commands/InviteCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/InviteCommand.java
@@ -37,7 +37,7 @@ public class InviteCommand extends SubCommand {
             player.sendMessage(translate("&c" + getText("UsageInvite")));
             return;
         }
-        if (faction.getFlags().getFlag("officerRankRequiredToInviteOthers")) {
+        if (faction.getFlags().getFlag("mustBeOfficerToInviteOthers")) {
             // officer or owner rank required
             if (!faction.isOfficer(player.getUniqueId()) && !faction.isOwner(player.getUniqueId())) {
                 player.sendMessage(translate("&c" + getText("AlertMustBeOwnerOrOfficerToUseCommand")));

--- a/src/main/java/dansplugins/factionsystem/commands/InviteCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/InviteCommand.java
@@ -19,7 +19,7 @@ public class InviteCommand extends SubCommand {
     public InviteCommand() {
         super(new String[]{
                 "invite", LOCALE_PREFIX + "CmdInvite"
-        }, true, true, true, false);
+        }, true, true);
     }
 
     /**
@@ -36,6 +36,13 @@ public class InviteCommand extends SubCommand {
         if (args.length <= 0) {
             player.sendMessage(translate("&c" + getText("UsageInvite")));
             return;
+        }
+        if (faction.getFlags().getFlag("officerRankRequiredToInviteOthers")) {
+            // officer or owner rank required
+            if (!faction.isOfficer(player.getUniqueId()) && !faction.isOwner(player.getUniqueId())) {
+                player.sendMessage(translate("&c" + getText("AlertMustBeOwnerOrOfficerToUseCommand")));
+                return;
+            }
         }
         final UUID playerUUID = UUIDChecker.getInstance().findUUIDBasedOnPlayerName(args[0]);
         if (playerUUID == null) {

--- a/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
@@ -1,6 +1,8 @@
 package dansplugins.factionsystem.commands;
 
 import dansplugins.factionsystem.commands.abs.SubCommand;
+import dansplugins.factionsystem.data.EphemeralData;
+import dansplugins.factionsystem.objects.Faction;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -23,7 +25,16 @@ public class UnclaimCommand extends SubCommand {
     public void execute(Player player, String[] args, String key) {
         final String permission = "mf.unclaim";
         if (!(checkPermissions(player, permission))) return;
-        chunks.removeChunkAtPlayerLocation(player);
+        final boolean isPlayerBypassing = EphemeralData.getInstance().getAdminsBypassingProtections().contains(player.getUniqueId());
+        final Faction playersFaction = getPlayerFaction(player.getUniqueId());
+        if (playersFaction.getFlags().getFlag("officerRankRequiredToManageLand")) {
+            // officer or owner rank required
+            if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId()) && !isPlayerBypassing) {
+                player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));
+                return;
+            }
+        }
+        chunks.removeChunkAtPlayerLocation(player, playersFaction);
         dynmap.updateClaims();
         // TODO: 12/05/2021 Locale Message.
     }

--- a/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
@@ -27,7 +27,7 @@ public class UnclaimCommand extends SubCommand {
         if (!(checkPermissions(player, permission))) return;
         final boolean isPlayerBypassing = EphemeralData.getInstance().getAdminsBypassingProtections().contains(player.getUniqueId());
         final Faction playersFaction = getPlayerFaction(player.getUniqueId());
-        if (playersFaction.getFlags().getFlag("officerRankRequiredToManageLand")) {
+        if (playersFaction.getFlags().getFlag("mustBeOfficerToManageLand")) {
             // officer or owner rank required
             if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId()) && !isPlayerBypassing) {
                 player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));

--- a/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
@@ -26,15 +26,14 @@ public class UnclaimCommand extends SubCommand {
         final String permission = "mf.unclaim";
         if (!(checkPermissions(player, permission))) return;
         final boolean isPlayerBypassing = EphemeralData.getInstance().getAdminsBypassingProtections().contains(player.getUniqueId());
-        final Faction playersFaction = getPlayerFaction(player.getUniqueId());
-        if (playersFaction.getFlags().getFlag("mustBeOfficerToManageLand")) {
+        if (faction.getFlags().getFlag("mustBeOfficerToManageLand")) {
             // officer or owner rank required
-            if (!playersFaction.isOfficer(player.getUniqueId()) && !playersFaction.isOwner(player.getUniqueId()) && !isPlayerBypassing) {
+            if (!faction.isOfficer(player.getUniqueId()) && !faction.isOwner(player.getUniqueId()) && !isPlayerBypassing) {
                 player.sendMessage(translate("&c" + getText("AlertMustBeOfficerOrOwnerToClaimLand")));
                 return;
             }
         }
-        chunks.removeChunkAtPlayerLocation(player, playersFaction);
+        chunks.removeChunkAtPlayerLocation(player, faction);
         dynmap.updateClaims();
         // TODO: 12/05/2021 Locale Message.
     }

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
@@ -35,7 +35,7 @@ import static org.bukkit.Material.LADDER;
 
 public class InteractionHandler implements Listener {
 
-    private final boolean debug = false;
+    private final boolean debug = true;
 
     // EVENT HANDLER METHODS ------------------------------------------------------
 
@@ -428,6 +428,11 @@ public class InteractionHandler implements Listener {
         boolean isAlly = faction.isAlly(chunk.getHolder());
         boolean allyInteractionAllowed = faction.getFlags().getFlag("alliesCanInteractWithLand");
         boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
+
+        if (debug) {
+            System.out.println("[DEBUG] allyInteractionAllowed: " + allyInteractionAllowed);
+            System.out.println("[DEBUG] vassalageTreeInteractionAllowed: " + vassalageTreeInteractionAllowed);
+        }
 
         boolean allowed = false;
 

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
@@ -426,7 +426,7 @@ public class InteractionHandler implements Listener {
     private boolean isOutsiderInteractionAllowed(Player player, ClaimedChunk chunk, Faction faction) {
         boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(player, PersistentData.getInstance().getFaction(chunk.getHolder()));
         boolean isAlly = faction.isAlly(chunk.getHolder());
-        boolean allyInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowAllyInteraction");
+        boolean allyInteractionAllowed = faction.getFlags().getFlag("alliesCanInteractWithLand");
         boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
 
         boolean allowed = false;

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
@@ -12,6 +12,7 @@ import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.objects.Gate;
 import dansplugins.factionsystem.objects.LockedBlock;
 import dansplugins.factionsystem.utils.BlockChecker;
+import dansplugins.factionsystem.utils.InteractionAccessChecker;
 import dansplugins.factionsystem.utils.UUIDChecker;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -47,7 +48,7 @@ public class InteractionHandler implements Listener {
         // get chunk
         ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(event.getBlock().getLocation().getChunk());
 
-        if (shouldEventBeCancelled(claimedChunk, player)) {
+        if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
             event.setCancelled(true);
             return;
         }
@@ -102,11 +103,11 @@ public class InteractionHandler implements Listener {
         // get chunk
         ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(event.getBlock().getLocation().getChunk());
 
-        if (isPlayerAttemptingToPlaceLadderInEnemyTerritoryAndIsThisAllowed(event.getBlockPlaced(), player, claimedChunk)) {
+        if (InteractionAccessChecker.getInstance().isPlayerAttemptingToPlaceLadderInEnemyTerritoryAndIsThisAllowed(event.getBlockPlaced(), player, claimedChunk)) {
             return;
         }
 
-        if (shouldEventBeCancelled(claimedChunk, player)) {
+        if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
             event.setCancelled(true);
             return;
         }
@@ -292,7 +293,7 @@ public class InteractionHandler implements Listener {
             Chunk chunk = location.getChunk();
             ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(chunk);
 
-            if (shouldEventBeCancelled(claimedChunk, player)) {
+            if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
                 event.setCancelled(true);
             }
         }
@@ -312,7 +313,7 @@ public class InteractionHandler implements Listener {
         // get chunk that entity is in
         ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(entity.getLocation().getChunk());
 
-        if (shouldEventBeCancelled(claimedChunk, player)) {
+        if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
             event.setCancelled(true);
         }
     }
@@ -327,7 +328,7 @@ public class InteractionHandler implements Listener {
 
         ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(clickedBlock.getChunk());
 
-        if (shouldEventBeCancelled(claimedChunk, player)) {
+        if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
             event.setCancelled(true);
         }
     }
@@ -342,7 +343,7 @@ public class InteractionHandler implements Listener {
 
         ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(clickedBlock.getChunk());
 
-        if (shouldEventBeCancelled(claimedChunk, player)) {
+        if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
             event.setCancelled(true);
         }
     }
@@ -357,7 +358,7 @@ public class InteractionHandler implements Listener {
 
         ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(clickedBlock.getChunk());
 
-        if (shouldEventBeCancelled(claimedChunk, player)) {
+        if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
             event.setCancelled(true);
         }
     }
@@ -378,7 +379,7 @@ public class InteractionHandler implements Listener {
             Chunk chunk = location.getChunk();
             ClaimedChunk claimedChunk = ChunkManager.getInstance().getClaimedChunk(chunk);
 
-            if (shouldEventBeCancelled(claimedChunk, player)) {
+            if (InteractionAccessChecker.getInstance().shouldEventBeCancelled(claimedChunk, player)) {
                 event.setCancelled(true);
             }
         }
@@ -392,77 +393,6 @@ public class InteractionHandler implements Listener {
         return EphemeralData.getInstance().getPlayersGrantingAccess().containsKey(player.getUniqueId()) ||
                 EphemeralData.getInstance().getPlayersCheckingAccess().contains(player.getUniqueId()) ||
                 EphemeralData.getInstance().getPlayersRevokingAccess().containsKey(player.getUniqueId());
-    }
-
-    private boolean shouldEventBeCancelled(ClaimedChunk claimedChunk, Player player) {
-        if (claimedChunk == null) {
-            // chunk is not claimed
-            return false;
-        }
-
-        boolean isPlayerBypassing = EphemeralData.getInstance().getAdminsBypassingProtections().contains(player.getUniqueId());
-        if (isPlayerBypassing) {
-            // player is bypassing
-            return false;
-        }
-
-        Faction playersFaction = PersistentData.getInstance().getPlayersFaction(player.getUniqueId());
-        if (playersFaction == null) {
-            // player is not in a faction
-            return true;
-        }
-
-        boolean isLandClaimedByPlayersFaction = playersFaction.getName().equalsIgnoreCase(claimedChunk.getHolder());
-        if (!isLandClaimedByPlayersFaction && !isOutsiderInteractionAllowed(player, claimedChunk, playersFaction)) {
-            // land is not claimed by players faction and outsider interaction is disallowed
-            return true;
-        }
-        else {
-            // land is claimed by players faction or outsider interaction is allowed
-            return false;
-        }
-    }
-
-    private boolean isOutsiderInteractionAllowed(Player player, ClaimedChunk chunk, Faction faction) {
-        boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(player, PersistentData.getInstance().getFaction(chunk.getHolder()));
-        boolean isAlly = faction.isAlly(chunk.getHolder());
-        boolean allyInteractionAllowed = faction.getFlags().getFlag("alliesCanInteractWithLand");
-        boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
-
-        if (debug) {
-            System.out.println("[DEBUG] allyInteractionAllowed: " + allyInteractionAllowed);
-            System.out.println("[DEBUG] vassalageTreeInteractionAllowed: " + vassalageTreeInteractionAllowed);
-        }
-
-        boolean allowed = false;
-
-        if (allyInteractionAllowed && isAlly) {
-            allowed = true;
-        }
-
-        if (vassalageTreeInteractionAllowed && inVassalageTree) {
-            allowed = true;
-        }
-
-        return allowed;
-    }
-
-    private boolean isPlayerAttemptingToPlaceLadderInEnemyTerritoryAndIsThisAllowed(Block blockPlaced, Player player, ClaimedChunk claimedChunk) {
-        Faction playersFaction = PersistentData.getInstance().getPlayersFaction(player.getUniqueId());
-
-        if (playersFaction == null) {
-            // player is not in a faction, so they couldn't be trying to place anything in enemy territory
-            return false;
-        }
-
-        if (claimedChunk == null) {
-            // chunk is not claimed, so they couldn't be trying to place anything in enemy territory
-            return false;
-        }
-
-        boolean laddersArePlaceableInEnemyTerritory = MedievalFactions.getInstance().getConfig().getBoolean("laddersPlaceableInEnemyFactionTerritory");
-        boolean playerIsTryingToPlaceLadderInEnemyTerritory = blockPlaced.getType() == LADDER && playersFaction.isEnemy(claimedChunk.getHolder());
-        return laddersArePlaceableInEnemyTerritory && playerIsTryingToPlaceLadderInEnemyTerritory;
     }
 
     // END OF HELPER METHODS ------------------------------------------------------

--- a/src/main/java/dansplugins/factionsystem/managers/ChunkManager.java
+++ b/src/main/java/dansplugins/factionsystem/managers/ChunkManager.java
@@ -275,15 +275,14 @@ public class ChunkManager {
         return (numExperiencingPowerDecay == faction.getMemberArrayList().size());
     }
 
-    public void removeChunkAtPlayerLocation(Player player) {
+    public void removeChunkAtPlayerLocation(Player player, Faction playersFaction) {
         double[] playerCoords = new double[2];
         playerCoords[0] = player.getLocation().getChunk().getX();
         playerCoords[1] = player.getLocation().getChunk().getZ();
 
         if (EphemeralData.getInstance().getAdminsBypassingProtections().contains(player.getUniqueId())) {
             ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
-            if (chunk != null)
-            {
+            if (chunk != null) {
                 removeChunk(chunk, player, PersistentData.getInstance().getFaction(chunk.getHolder()));
                 player.sendMessage(ChatColor.GREEN + LocaleManager.getInstance().getText("LandClaimedUsingAdminBypass"));
                 return;
@@ -292,25 +291,19 @@ public class ChunkManager {
             return;
         }
 
-        for (Faction faction : PersistentData.getInstance().getFactions()) {
-            if (faction.isOwner(player.getUniqueId()) || faction.isOfficer(player.getUniqueId())) {
-                // check if land is claimed by player's faction
-                ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
-                if (chunk != null)
-                {
-                    // if holder is player's faction
-                    if (chunk.getHolder().equalsIgnoreCase(faction.getName())) {
-                        removeChunk(chunk, player, faction);
-                        player.sendMessage(ChatColor.GREEN + LocaleManager.getInstance().getText("LandUnclaimed"));
-
-                        return;
-                    }
-                    else {
-                        player.sendMessage(ChatColor.RED + String.format(LocaleManager.getInstance().getText("LandClaimedBy"), chunk.getHolder()));
-                        return;
-                    }
-                }
-
+        // check if land is claimed by player's faction
+        ClaimedChunk chunk = isChunkClaimed(playerCoords[0], playerCoords[1], player.getLocation().getWorld().getName());
+        if (chunk != null)
+        {
+            // if holder is player's faction
+            if (chunk.getHolder().equalsIgnoreCase(playersFaction.getName())) {
+                removeChunk(chunk, player, playersFaction);
+                player.sendMessage(ChatColor.GREEN + LocaleManager.getInstance().getText("LandUnclaimed"));
+                return;
+            }
+            else {
+                player.sendMessage(ChatColor.RED + String.format(LocaleManager.getInstance().getText("LandClaimedBy"), chunk.getHolder()));
+                return;
             }
         }
     }

--- a/src/main/java/dansplugins/factionsystem/managers/ChunkManager.java
+++ b/src/main/java/dansplugins/factionsystem/managers/ChunkManager.java
@@ -8,6 +8,7 @@ import dansplugins.factionsystem.events.FactionClaimEvent;
 import dansplugins.factionsystem.events.FactionUnclaimEvent;
 import dansplugins.factionsystem.objects.*;
 import dansplugins.factionsystem.utils.BlockChecker;
+import dansplugins.factionsystem.utils.InteractionAccessChecker;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -527,28 +528,10 @@ public class ChunkManager {
                             }
                         }
                     }
-                    // =======================
-                    // TODO: replace this code with a call to the isOutsiderInteractionAllowed() method
-                    boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(event.getPlayer(), PersistentData.getInstance().getFaction(chunk.getHolder()));
-                    boolean isAlly = faction.isAlly(chunk.getHolder());
-                    boolean allyInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowAllyInteraction");
-                    boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
-
-                    boolean allowed = false;
-
-                    if (allyInteractionAllowed && isAlly) {
-                        allowed = true;
-                    }
-
-                    if (vassalageTreeInteractionAllowed && inVassalageTree) {
-                        allowed = true;
-                    }
-
-                    if (!allowed) {
+                    if (!InteractionAccessChecker.getInstance().isOutsiderInteractionAllowed(event.getPlayer(), chunk, faction)) {
                         event.setCancelled(true);
                         return;
                     }
-                    // =======================
                 }
             }
         }

--- a/src/main/java/dansplugins/factionsystem/objects/Faction.java
+++ b/src/main/java/dansplugins/factionsystem/objects/Faction.java
@@ -52,7 +52,7 @@ public class Faction {
         setOwner(creator);
         maxPower = max;
         prefix = initialName;
-        flags.initializeFlags();
+        flags.initializeFlagValues();
     }
 
     // server constructor
@@ -410,7 +410,6 @@ public class Faction {
         }
         saveMap.put("factionGates", gson.toJson(gateList));
 
-        saveMap.put("flagNames", gson.toJson(flags.getFlagNames()));
         saveMap.put("flagValues", gson.toJson(flags.getFlagValues()));
 
         return saveMap;
@@ -467,11 +466,10 @@ public class Faction {
         	System.out.println(LocaleManager.getInstance().getText("MissingFactionGatesJSONCollection"));
         }
 
-        flags.setFlagNames(gson.fromJson(data.getOrDefault("flagNames", "[]"), arrayListTypeString));
         flags.setFlagValues(gson.fromJson(data.getOrDefault("flagValues", "[]"), mapType2));
 
         if (flags.getNumFlags() == 0) {
-            flags.initializeFlags();
+            flags.initializeFlagValues();
         }
     }
 

--- a/src/main/java/dansplugins/factionsystem/objects/Faction.java
+++ b/src/main/java/dansplugins/factionsystem/objects/Faction.java
@@ -410,7 +410,8 @@ public class Faction {
         }
         saveMap.put("factionGates", gson.toJson(gateList));
 
-        // TODO: save FactionFlags object
+        saveMap.put("flagNames", gson.toJson(flags.getFlagNames()));
+        saveMap.put("flagValues", gson.toJson(flags.getFlagValues()));
 
         return saveMap;
     }
@@ -434,6 +435,7 @@ public class Faction {
         Type arrayListTypeString = new TypeToken<ArrayList<String>>(){}.getType();
         Type arrayListTypeUUID = new TypeToken<ArrayList<UUID>>(){}.getType();
         Type mapType = new TypeToken<HashMap<String, String>>(){}.getType();
+        Type mapType2 = new TypeToken<HashMap<String, Boolean>>(){}.getType();
 
         members = gson.fromJson(data.get("members"), arrayListTypeUUID);
         enemyFactions = gson.fromJson(data.get("enemyFactions"), arrayListTypeString);
@@ -465,7 +467,8 @@ public class Faction {
         	System.out.println(LocaleManager.getInstance().getText("MissingFactionGatesJSONCollection"));
         }
 
-        // TODO: load FactionFlags object
+        flags.setFlagNames(gson.fromJson(data.getOrDefault("flagNames", "[]"), arrayListTypeString));
+        flags.setFlagValues(gson.fromJson(data.getOrDefault("flagValues", "[]"), mapType2));
 
         if (flags.getNumFlags() == 0) {
             flags.initializeFlags();

--- a/src/main/java/dansplugins/factionsystem/objects/Faction.java
+++ b/src/main/java/dansplugins/factionsystem/objects/Faction.java
@@ -468,9 +468,7 @@ public class Faction {
 
         flags.setFlagValues(gson.fromJson(data.getOrDefault("flagValues", "[]"), mapType2));
 
-        if (flags.getNumFlags() == 0) {
-            flags.initializeFlagValues();
-        }
+        flags.loadMissingFlagsIfNecessary();
     }
 
     private String loadDataOrDefault(Gson gson, Map<String, String> data, String key, String def) {

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -17,21 +17,21 @@ public class FactionFlags {
     }
 
     private void initializeFlagNames() { // this is called internally
-        flagNames.add("officerRankRequiredToManageLand");
-        flagNames.add("officerRankRequiredToInviteOthers");
+        flagNames.add("mustBeOfficerToManageLand");
+        flagNames.add("mustBeOfficerToInviteOthers");
     }
 
     public void initializeFlagValues() { // this is called externally in Faction.java
-        flagValues.put("officerRankRequiredToManageLand", true);
-        flagValues.put("officerRankRequiredToInviteOthers", true);
+        flagValues.put("mustBeOfficerToManageLand", true);
+        flagValues.put("mustBeOfficerToInviteOthers", true);
     }
 
     public void loadMissingFlagsIfNecessary() {
-        if (!flagValues.containsKey("officerRankRequiredToManageLand")) {
-            flagValues.put("officerRankRequiredToManageLand", true);
+        if (!flagValues.containsKey("mustBeOfficerToManageLand")) {
+            flagValues.put("mustBeOfficerToManageLand", true);
         }
-        if (!flagValues.containsKey("officerRankRequiredToInviteOthers")) {
-            flagValues.put("officerRankRequiredToInviteOthers", true);
+        if (!flagValues.containsKey("mustBeOfficerToInviteOthers")) {
+            flagValues.put("mustBeOfficerToInviteOthers", true);
         }
     }
 

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -1,5 +1,6 @@
 package dansplugins.factionsystem.objects;
 
+import dansplugins.factionsystem.MedievalFactions;
 import dansplugins.factionsystem.managers.LocaleManager;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -19,19 +20,26 @@ public class FactionFlags {
     private void initializeFlagNames() { // this is called internally
         flagNames.add("mustBeOfficerToManageLand");
         flagNames.add("mustBeOfficerToInviteOthers");
+        flagNames.add("alliesCanInteractWithLand");
     }
 
-    public void initializeFlagValues() { // this is called externally in Faction.java
+    public void initializeFlagValues() {
+        // this is called externally in Faction.java when a faction is created in-game
         flagValues.put("mustBeOfficerToManageLand", true);
         flagValues.put("mustBeOfficerToInviteOthers", true);
+        flagValues.put("alliesCanInteractWithLand", MedievalFactions.getInstance().getConfig().getBoolean("allowAllyInteraction"));
     }
 
     public void loadMissingFlagsIfNecessary() {
+        // this is called externally in Faction.java when a faction is loaded from save files
         if (!flagValues.containsKey("mustBeOfficerToManageLand")) {
             flagValues.put("mustBeOfficerToManageLand", true);
         }
         if (!flagValues.containsKey("mustBeOfficerToInviteOthers")) {
             flagValues.put("mustBeOfficerToInviteOthers", true);
+        }
+        if (!flagValues.containsKey("alliesCanInteractWithLand")) {
+            flagValues.put("alliesCanInteractWithLand", MedievalFactions.getInstance().getConfig().getBoolean("allowAllyInteraction"));
         }
     }
 

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -30,6 +30,12 @@ public class FactionFlags {
         flagValues.put("officerRankRequiredToClaimLand", true);
     }
 
+    public void loadMissingFlagsIfNecessary() {
+        if (!flagValues.containsKey("officerRankRequiredToClaimLand")) {
+            flagValues.put("officerRankRequiredToClaimLand", true);
+        }
+    }
+
     public void sendFlagList(Player player) {
         player.sendMessage(ChatColor.AQUA + "" + getFlagsSeparatedByCommas());
     }

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -23,6 +23,7 @@ public class FactionFlags {
         flagNames.add("mustBeOfficerToManageLand");
         flagNames.add("mustBeOfficerToInviteOthers");
         flagNames.add("alliesCanInteractWithLand");
+        flagNames.add("vassalageTreeCanInteractWithLand");
     }
 
     public void initializeFlagValues() {
@@ -30,6 +31,7 @@ public class FactionFlags {
         flagValues.put("mustBeOfficerToManageLand", true);
         flagValues.put("mustBeOfficerToInviteOthers", true);
         flagValues.put("alliesCanInteractWithLand", MedievalFactions.getInstance().getConfig().getBoolean("allowAllyInteraction"));
+        flagValues.put("vassalageTreeCanInteractWithLand", MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction"));
     }
 
     public void loadMissingFlagsIfNecessary() {
@@ -42,6 +44,9 @@ public class FactionFlags {
         }
         if (!flagValues.containsKey("alliesCanInteractWithLand")) {
             flagValues.put("alliesCanInteractWithLand", MedievalFactions.getInstance().getConfig().getBoolean("allowAllyInteraction"));
+        }
+        if (!flagValues.containsKey("vassalageTreeCanInteractWithLand")) {
+            flagValues.put("vassalageTreeCanInteractWithLand", MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction"));
         }
     }
 

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -1,34 +1,70 @@
 package dansplugins.factionsystem.objects;
 
+import dansplugins.factionsystem.MedievalFactions;
+import dansplugins.factionsystem.managers.LocaleManager;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
 import java.util.HashMap;
 
 public class FactionFlags {
 
-    private HashMap<String, Boolean> flags = new HashMap<>();
+    private ArrayList<String> flagNames = new ArrayList<>();
+    private HashMap<String, Boolean> flagValues = new HashMap<>();
 
     public int getNumFlags() {
-        return flags.size();
+        return flagValues.size();
     }
 
     public void initializeFlags() {
-        flags.put("TestFlag", true);
+        flagNames.add("TestFlag");
+        flagValues.put("TestFlag", true);
+
+        flagNames.add("TestFlag2");
+        flagValues.put("TestFlag2", true);
+
+        flagNames.add("TestFlag2");
+        flagValues.put("TestFlag2", true);
+    }
+
+    public void sendFlagList(Player player) {
+        player.sendMessage(ChatColor.AQUA + "" + getFlagsSeparatedByCommas());
+    }
+
+
+    public void setFlag(String flag, String value, Player player) {
+        if (isFlag(flag)) {
+            flagValues.replace(flag, Boolean.parseBoolean(value));
+            player.sendMessage(ChatColor.GREEN + LocaleManager.getInstance().getText("BooleanSet"));
+        }
+        else {
+            player.sendMessage(ChatColor.RED + String.format(LocaleManager.getInstance().getText("WasntFound"), flag));
+        }
     }
 
     public boolean getFlag(String flag) {
         if (!isFlag(flag)) {
             return false;
         }
-        return flags.get(flag);
+        return flagValues.get(flag);
     }
 
-    public void setFlag(String flag, boolean value) {
-        // this should never cause an issue as we will sanitize user input
-        flags.replace(flag, value);
-    }
-
-    public boolean isFlag(String flag) {
+    private boolean isFlag(String flag) {
         // this method will likely need to be used to sanitize user input
-        return flags.containsKey(flag);
+        return flagValues.containsKey(flag);
+    }
+
+    private String getFlagsSeparatedByCommas() {
+        String toReturn = "";
+        for (String flagName : flagNames) {
+            if (!toReturn.equals("")) {
+                toReturn += ", ";
+            }
+            toReturn += String.format("%s: %s", flagName, flagValues.get(flagName));
+        }
+        return toReturn;
     }
 
 }

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -14,19 +14,20 @@ public class FactionFlags {
     private ArrayList<String> flagNames = new ArrayList<>();
     private HashMap<String, Boolean> flagValues = new HashMap<>();
 
+    public FactionFlags() {
+        initializeFlagNames();
+    }
+
     public int getNumFlags() {
         return flagValues.size();
     }
 
-    public void initializeFlags() {
-        flagNames.add("TestFlag");
-        flagValues.put("TestFlag", true);
+    private void initializeFlagNames() { // this is called internally
+        flagNames.add("officerRankRequiredToClaimLand");
+    }
 
-        flagNames.add("TestFlag2");
-        flagValues.put("TestFlag2", true);
-
-        flagNames.add("TestFlag3");
-        flagValues.put("TestFlag3", true);
+    public void initializeFlagValues() { // this is called externally in Faction.java
+        flagValues.put("officerRankRequiredToClaimLand", true);
     }
 
     public void sendFlagList(Player player) {
@@ -69,7 +70,7 @@ public class FactionFlags {
 
     private boolean isFlag(String flag) {
         // this method will likely need to be used to sanitize user input
-        return flagValues.containsKey(flag);
+        return flagNames.contains(flag);
     }
 
     private String getFlagsSeparatedByCommas() {

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -25,8 +25,8 @@ public class FactionFlags {
         flagNames.add("TestFlag2");
         flagValues.put("TestFlag2", true);
 
-        flagNames.add("TestFlag2");
-        flagValues.put("TestFlag2", true);
+        flagNames.add("TestFlag3");
+        flagValues.put("TestFlag3", true);
     }
 
     public void sendFlagList(Player player) {
@@ -49,6 +49,22 @@ public class FactionFlags {
             return false;
         }
         return flagValues.get(flag);
+    }
+
+    public ArrayList<String> getFlagNames() {
+        return flagNames;
+    }
+
+    public HashMap<String, Boolean> getFlagValues() {
+        return flagValues;
+    }
+
+    public void setFlagNames(ArrayList<String> names) {
+        flagNames = names;
+    }
+
+    public void setFlagValues(HashMap<String, Boolean> values) {
+        flagValues = values;
     }
 
     private boolean isFlag(String flag) {

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 
 public class FactionFlags {
 
+    private final boolean debug = true;
+
     private ArrayList<String> flagNames = new ArrayList<>();
     private HashMap<String, Boolean> flagValues = new HashMap<>();
 
@@ -60,8 +62,10 @@ public class FactionFlags {
 
     public boolean getFlag(String flag) {
         if (!isFlag(flag)) {
+            if (debug) { System.out.println(String.format("[DEBUG] Flag '%s' was not found!", flag)); }
             return false;
         }
+        if (debug) { System.out.println(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, flagValues.get(flag))); }
         return flagValues.get(flag);
     }
 

--- a/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/FactionFlags.java
@@ -1,9 +1,7 @@
 package dansplugins.factionsystem.objects;
 
-import dansplugins.factionsystem.MedievalFactions;
 import dansplugins.factionsystem.managers.LocaleManager;
 import org.bukkit.ChatColor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -18,21 +16,22 @@ public class FactionFlags {
         initializeFlagNames();
     }
 
-    public int getNumFlags() {
-        return flagValues.size();
-    }
-
     private void initializeFlagNames() { // this is called internally
-        flagNames.add("officerRankRequiredToClaimLand");
+        flagNames.add("officerRankRequiredToManageLand");
+        flagNames.add("officerRankRequiredToInviteOthers");
     }
 
     public void initializeFlagValues() { // this is called externally in Faction.java
-        flagValues.put("officerRankRequiredToClaimLand", true);
+        flagValues.put("officerRankRequiredToManageLand", true);
+        flagValues.put("officerRankRequiredToInviteOthers", true);
     }
 
     public void loadMissingFlagsIfNecessary() {
-        if (!flagValues.containsKey("officerRankRequiredToClaimLand")) {
-            flagValues.put("officerRankRequiredToClaimLand", true);
+        if (!flagValues.containsKey("officerRankRequiredToManageLand")) {
+            flagValues.put("officerRankRequiredToManageLand", true);
+        }
+        if (!flagValues.containsKey("officerRankRequiredToInviteOthers")) {
+            flagValues.put("officerRankRequiredToInviteOthers", true);
         }
     }
 
@@ -58,16 +57,8 @@ public class FactionFlags {
         return flagValues.get(flag);
     }
 
-    public ArrayList<String> getFlagNames() {
-        return flagNames;
-    }
-
     public HashMap<String, Boolean> getFlagValues() {
         return flagValues;
-    }
-
-    public void setFlagNames(ArrayList<String> names) {
-        flagNames = names;
     }
 
     public void setFlagValues(HashMap<String, Boolean> values) {
@@ -77,6 +68,10 @@ public class FactionFlags {
     private boolean isFlag(String flag) {
         // this method will likely need to be used to sanitize user input
         return flagNames.contains(flag);
+    }
+
+    public int getNumFlags() {
+        return flagValues.size();
     }
 
     private String getFlagsSeparatedByCommas() {

--- a/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
+++ b/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
@@ -1,0 +1,101 @@
+package dansplugins.factionsystem.utils;
+
+import dansplugins.factionsystem.MedievalFactions;
+import dansplugins.factionsystem.data.EphemeralData;
+import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.objects.ClaimedChunk;
+import dansplugins.factionsystem.objects.Faction;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+
+import static org.bukkit.Material.LADDER;
+
+public class InteractionAccessChecker {
+
+    final private boolean debug = true;
+
+    private static InteractionAccessChecker instance;
+
+    private InteractionAccessChecker() {
+
+    }
+
+    public static InteractionAccessChecker getInstance() {
+        if (instance == null) {
+            instance = new InteractionAccessChecker();
+        }
+        return instance;
+    }
+
+    public boolean shouldEventBeCancelled(ClaimedChunk claimedChunk, Player player) {
+        if (claimedChunk == null) {
+            // chunk is not claimed
+            return false;
+        }
+
+        boolean isPlayerBypassing = EphemeralData.getInstance().getAdminsBypassingProtections().contains(player.getUniqueId());
+        if (isPlayerBypassing) {
+            // player is bypassing
+            return false;
+        }
+
+        Faction playersFaction = PersistentData.getInstance().getPlayersFaction(player.getUniqueId());
+        if (playersFaction == null) {
+            // player is not in a faction
+            return true;
+        }
+
+        boolean isLandClaimedByPlayersFaction = playersFaction.getName().equalsIgnoreCase(claimedChunk.getHolder());
+        if (!isLandClaimedByPlayersFaction && !isOutsiderInteractionAllowed(player, claimedChunk, playersFaction)) {
+            // land is not claimed by players faction and outsider interaction is disallowed
+            return true;
+        }
+        else {
+            // land is claimed by players faction or outsider interaction is allowed
+            return false;
+        }
+    }
+
+    public boolean isOutsiderInteractionAllowed(Player player, ClaimedChunk chunk, Faction playersFaction) {
+        boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(player, PersistentData.getInstance().getFaction(chunk.getHolder()));
+        boolean isAlly = playersFaction.isAlly(chunk.getHolder());
+        boolean allyInteractionAllowed = playersFaction.getFlags().getFlag("alliesCanInteractWithLand");
+        boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
+
+        if (debug) {
+            System.out.println("[DEBUG] allyInteractionAllowed: " + allyInteractionAllowed);
+            System.out.println("[DEBUG] vassalageTreeInteractionAllowed: " + vassalageTreeInteractionAllowed);
+        }
+
+        boolean allowed = false;
+
+        if (allyInteractionAllowed && isAlly) {
+            allowed = true;
+        }
+
+        if (vassalageTreeInteractionAllowed && inVassalageTree) {
+            allowed = true;
+        }
+
+        return allowed;
+    }
+
+    public boolean isPlayerAttemptingToPlaceLadderInEnemyTerritoryAndIsThisAllowed(Block blockPlaced, Player player, ClaimedChunk claimedChunk) {
+        Faction playersFaction = PersistentData.getInstance().getPlayersFaction(player.getUniqueId());
+
+        if (playersFaction == null) {
+            // player is not in a faction, so they couldn't be trying to place anything in enemy territory
+            return false;
+        }
+
+        if (claimedChunk == null) {
+            // chunk is not claimed, so they couldn't be trying to place anything in enemy territory
+            return false;
+        }
+
+        boolean laddersArePlaceableInEnemyTerritory = MedievalFactions.getInstance().getConfig().getBoolean("laddersPlaceableInEnemyFactionTerritory");
+        boolean playerIsTryingToPlaceLadderInEnemyTerritory = blockPlaced.getType() == LADDER && playersFaction.isEnemy(claimedChunk.getHolder());
+        return laddersArePlaceableInEnemyTerritory && playerIsTryingToPlaceLadderInEnemyTerritory;
+    }
+
+}

--- a/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
+++ b/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
@@ -57,9 +57,11 @@ public class InteractionAccessChecker {
     }
 
     public boolean isOutsiderInteractionAllowed(Player player, ClaimedChunk chunk, Faction playersFaction) {
-        boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(player, PersistentData.getInstance().getFaction(chunk.getHolder()));
+        final Faction chunkHolder = PersistentData.getInstance().getFaction(chunk.getHolder());
+
+        boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(player, chunkHolder);
         boolean isAlly = playersFaction.isAlly(chunk.getHolder());
-        boolean allyInteractionAllowed = playersFaction.getFlags().getFlag("alliesCanInteractWithLand");
+        boolean allyInteractionAllowed = chunkHolder.getFlags().getFlag("alliesCanInteractWithLand");
         boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
 
         if (debug) {

--- a/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
+++ b/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
@@ -62,7 +62,7 @@ public class InteractionAccessChecker {
         boolean inVassalageTree = PersistentData.getInstance().isPlayerInFactionInVassalageTree(player, chunkHolder);
         boolean isAlly = playersFaction.isAlly(chunk.getHolder());
         boolean allyInteractionAllowed = chunkHolder.getFlags().getFlag("alliesCanInteractWithLand");
-        boolean vassalageTreeInteractionAllowed = MedievalFactions.getInstance().getConfig().getBoolean("allowVassalageTreeInteraction");
+        boolean vassalageTreeInteractionAllowed = chunkHolder.getFlags().getFlag("vassalageTreeCanInteractWithLand");
 
         if (debug) {
             System.out.println("[DEBUG] allyInteractionAllowed: " + allyInteractionAllowed);

--- a/src/main/resources/en-us.tsv
+++ b/src/main/resources/en-us.tsv
@@ -508,3 +508,6 @@ CannotDemoteSelf	You cannot demote yourself.
 CannotPromoteSelf	You cannot promote yourself.
 CannotRevokeAccessFromSelf	You cannot revoke access from yourself.
 CannotGrantAccessToSelf	You cannot grant access to yourself.
+CmdFlagsSet	set
+CmdFlagsShow	show
+UsageFlagsSet	Usage: /mf flags set (option) (value)

--- a/src/main/resources/en-us.tsv
+++ b/src/main/resources/en-us.tsv
@@ -508,6 +508,9 @@ CannotDemoteSelf	You cannot demote yourself.
 CannotPromoteSelf	You cannot promote yourself.
 CannotRevokeAccessFromSelf	You cannot revoke access from yourself.
 CannotGrantAccessToSelf	You cannot grant access to yourself.
+CmdFlags	flags
 CmdFlagsSet	set
 CmdFlagsShow	show
 UsageFlagsSet	Usage: /mf flags set (option) (value)
+HelpFlagsSet	/mf flags set (option) (value) - Set a faction flag.
+HelpFlagsShow	/mf flags show - Show faction flags.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -105,6 +105,8 @@ permissions:
     default: true
   mf.prefix:
     default: true
+  mf.flags:
+    default: true
   mf.bypass:
     default: op
   mf.config:


### PR DESCRIPTION
The Faction Flags Feature is now fully implemented. Faction flags are persistent and there are currently four flags that owners of factions can use to customize the mechanics of their factions.

closes #333 
closes #848 
closes #853 
closes #1038 
closes #1039 
closes #1040 
closes #1043 
closes #1044 
closes #1045 
closes #1046 
closes #1047 
