### PR TITLE
PowerCommand.java now uses the value associated with the "PlayerNotFound" key when the target player is not found

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/PowerCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/PowerCommand.java
@@ -52,7 +52,7 @@ public class PowerCommand extends SubCommand {
 		}
 		final UUID target = UUIDChecker.getInstance().findUUIDBasedOnPlayerName(args[0]);
 		if (target == null) {
-			sender.sendMessage(translate("&c" + getText("PlayerByNameNotFound")));
+			sender.sendMessage(translate("&c" + getText("PlayerNotFound")));
 			return;
 		}
 		record = data.getPlayersPowerRecord(target);


### PR DESCRIPTION
closes #1051 