### PR TITLE
finishDuel() method now has calls to clear active potion effects on participating players

### DIFF
--- a/src/main/java/dansplugins/factionsystem/objects/Duel.java
+++ b/src/main/java/dansplugins/factionsystem/objects/Duel.java
@@ -186,7 +186,11 @@ public class Duel {
 	{
 		_challenger.setHealth(challengerHealth);
 		_challenged.setHealth(challengedHealth);
-		
+
+		// Remove player damaging effects like fire or poison before ending the duel.
+		_challenged.getActivePotionEffects().clear();
+		_challenger.getActivePotionEffects().clear();
+
 		if (!tied)
 		{
 			// Announce winner to nearby players.


### PR DESCRIPTION
Caibinus was responsible for this fix. This still needs to be tested before merging.

closes #992 