### PR TITLE
Force Claim Command

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -564,7 +564,7 @@ public class ForceCommand extends SubCommand {
         }
 
         // claim land at player location for designated faction
-        ChunkManager.getInstance().claimChunkAtLocation(player, player.getLocation(), faction);
+        ChunkManager.getInstance().forceClaimAtPlayerLocation(player, faction);
     }
 
 }

--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -25,7 +25,7 @@ public class ForceCommand extends SubCommand {
     private final boolean debug = false;
 
     private final String[] commands = new String[]{
-            "Save", "Load", "Peace", "Demote", "Join", "Kick", "Power", "Renounce", "Transfer", "RemoveVassal", "Rename", "BonusPower", "Unlock", "Create"
+            "Save", "Load", "Peace", "Demote", "Join", "Kick", "Power", "Renounce", "Transfer", "RemoveVassal", "Rename", "BonusPower", "Unlock", "Create", "Claim"
     };
     private final HashMap<List<String>, String> subMap = new HashMap<>();
 
@@ -530,7 +530,7 @@ public class ForceCommand extends SubCommand {
         }
     }
 
-    public void forceClaim(CommandSender sender, String[] args) {
+    public void forceClaim(CommandSender sender, String[] args) { // TODO: add CmdForceClaim locale message
         if (!(sender instanceof Player)) {
             return;
         }

--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -565,6 +565,9 @@ public class ForceCommand extends SubCommand {
 
         // claim land at player location for designated faction
         ChunkManager.getInstance().forceClaimAtPlayerLocation(player, faction);
+
+        // inform sender
+        sender.sendMessage(translate("&a" + getText("Done")));
     }
 
 }

--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -531,7 +531,7 @@ public class ForceCommand extends SubCommand {
         }
     }
 
-    public void forceClaim(CommandSender sender, String[] args) { // TODO: add CmdForceClaim locale message
+    public void forceClaim(CommandSender sender, String[] args) {
         if (!(sender instanceof Player)) {
             return;
         }
@@ -543,7 +543,7 @@ public class ForceCommand extends SubCommand {
         }
 
         if (args.length < 2) {
-            sender.sendMessage(translate("&c" + getText("UsageForceClaim"))); // TODO: add locale message
+            sender.sendMessage(translate("&c" + getText("UsageForceClaim")));
             return;
         }
 
@@ -559,7 +559,7 @@ public class ForceCommand extends SubCommand {
         Faction faction = PersistentData.getInstance().getFaction(factionName);
 
         if (faction == null) {
-            // TODO: send player faction not found locale message
+            sender.sendMessage(translate("&c" + getText("FactionNotFound")));
             return;
         }
 

--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -7,6 +7,7 @@ import dansplugins.factionsystem.events.FactionCreateEvent;
 import dansplugins.factionsystem.events.FactionJoinEvent;
 import dansplugins.factionsystem.events.FactionKickEvent;
 import dansplugins.factionsystem.events.FactionRenameEvent;
+import dansplugins.factionsystem.managers.ChunkManager;
 import dansplugins.factionsystem.managers.LocaleManager;
 import dansplugins.factionsystem.managers.StorageManager;
 import dansplugins.factionsystem.objects.Faction;
@@ -537,7 +538,7 @@ public class ForceCommand extends SubCommand {
 
         Player player = (Player) sender;
 
-        if (!(checkPermissions(player, "mf.force.claim", "mf.force.*", "mf.admin"))) { // TODO: add permission to plugin.yml
+        if (!(checkPermissions(player, "mf.force.claim", "mf.force.*", "mf.admin"))) {
             return;
         }
 
@@ -555,7 +556,15 @@ public class ForceCommand extends SubCommand {
 
         String factionName = singleQuoteArgs.get(0);
 
-        // TODO: claim land at player location for designated faction
+        Faction faction = PersistentData.getInstance().getFaction(factionName);
+
+        if (faction == null) {
+            // TODO: send player faction not found locale message
+            return;
+        }
+
+        // claim land at player location for designated faction
+        ChunkManager.getInstance().claimChunkAtLocation(player, player.getLocation(), faction);
     }
 
 }

--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -530,4 +530,32 @@ public class ForceCommand extends SubCommand {
         }
     }
 
+    public void forceClaim(CommandSender sender, String[] args) {
+        if (!(sender instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) sender;
+
+        if (!(checkPermissions(player, "mf.force.claim", "mf.force.*", "mf.admin"))) { // TODO: add permission to plugin.yml
+            return;
+        }
+
+        if (args.length < 2) {
+            sender.sendMessage(translate("&c" + getText("UsageForceClaim"))); // TODO: add locale message
+            return;
+        }
+
+        // get arguments designated by single quotes
+        final ArrayList<String> singleQuoteArgs = parser.getArgumentsInsideSingleQuotes(args);
+        if (singleQuoteArgs.size() < 1) {
+            sender.sendMessage(translate("&c" + getText("ArgumentsSingleQuotesRequirement")));
+            return;
+        }
+
+        String factionName = singleQuoteArgs.get(0);
+
+        // TODO: claim land at player location for designated faction
+    }
+
 }

--- a/src/main/java/dansplugins/factionsystem/managers/ChunkManager.java
+++ b/src/main/java/dansplugins/factionsystem/managers/ChunkManager.java
@@ -320,7 +320,7 @@ public class ChunkManager {
         }
 
         // if faction home is located on this chunk
-        Location factionHome = PersistentData.getInstance().getPlayersFaction(player.getUniqueId()).getFactionHome();
+        Location factionHome = faction.getFactionHome();
         if (factionHome != null) {
             if (factionHome.getChunk().getX() == chunk.getChunk().getX() && factionHome.getChunk().getZ() == chunk.getChunk().getZ()
                     && chunk.getWorld().equalsIgnoreCase(player.getLocation().getWorld().getName())) {
@@ -620,6 +620,18 @@ public class ChunkManager {
                 return true;
         }
         return false;
+    }
+
+    public void forceClaimAtPlayerLocation(Player player, Faction faction) {
+        Location location = player.getLocation();
+
+        ClaimedChunk claimedChunk = getClaimedChunk(location.getChunk());
+
+        if (claimedChunk != null) {
+            removeChunk(claimedChunk, player, faction);
+        }
+
+        addClaimedChunk(location.getChunk(), faction, location.getWorld());
     }
 
 }

--- a/src/main/resources/en-us.tsv
+++ b/src/main/resources/en-us.tsv
@@ -542,3 +542,6 @@ ArgumentMustBeNumber	Argument must be a number.
 ConfigListPageOne	===== Config List Page 1/2 =====
 ConfigListPageTwo	===== Config List Page 2/2 =====
 NotAnAllyOrVassal	%s isn't an ally or vassal of yours.
+CmdForceClaim	claim
+UsageForceClaim:	Usage: /mf force claim 'faction name'
+HelpForceClaim	/mf force claim

--- a/src/main/resources/en-us.tsv
+++ b/src/main/resources/en-us.tsv
@@ -543,5 +543,5 @@ ConfigListPageOne	===== Config List Page 1/2 =====
 ConfigListPageTwo	===== Config List Page 2/2 =====
 NotAnAllyOrVassal	%s isn't an ally or vassal of yours.
 CmdForceClaim	claim
-UsageForceClaim:	Usage: /mf force claim 'faction name'
-HelpForceClaim	/mf force claim
+UsageForceClaim	Usage: /mf force claim 'faction name'
+HelpForceClaim	/mf force claim 'faction name'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -147,3 +147,5 @@ permissions:
     default: op
   mf.force.create:
     default: op
+  mf.force.claim:
+    default: op


### PR DESCRIPTION
Using this command. admins should be able to claim land for other factions. This should help in the event that they need a memberless faction to own land.

closes #1104