### PR TITLE
Territory Information in the ActionBar

### DIFF
--- a/src/main/java/dansplugins/factionsystem/MedievalFactions.java
+++ b/src/main/java/dansplugins/factionsystem/MedievalFactions.java
@@ -18,7 +18,7 @@ public class MedievalFactions extends JavaPlugin {
     private static MedievalFactions instance;
     private static MedievalFactionsAPI API;
 
-    private final String version = "v4.2";
+    private final String version = "v4.2.1";
 
     public static MedievalFactions getInstance() {
         return instance;

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/JoiningLeavingAndSpawningHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/JoiningLeavingAndSpawningHandler.java
@@ -12,6 +12,7 @@ import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.objects.PlayerActivityRecord;
 import dansplugins.factionsystem.objects.PlayerPowerRecord;
 import dansplugins.factionsystem.utils.ColorChecker;
+import dansplugins.factionsystem.utils.TerritoryOwnerNotifier;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
@@ -99,26 +100,16 @@ public class JoiningLeavingAndSpawningHandler implements Listener {
 
     private void setPlayerActionBarTerritoryInfo(Player player) {
 		if(MedievalFactions.getInstance().getConfig().getBoolean("territoryIndicatorActionbar")) {
-			// TODO: This is massive code duplication
 			// if chunk is claimed
 			if (ChunkManager.getInstance().isClaimed(player.getLocation().getChunk(), PersistentData.getInstance().getClaimedChunks())) {
 				String factionName = ChunkManager.getInstance().getClaimedChunk(player.getLocation().getChunk()).getHolder();
 				Faction holder = PersistentData.getInstance().getFaction(factionName);
-				String title = factionName;
-				String territoryAlertColorString = (String) holder.getFlags().getFlag("territoryAlertColor");
-				ChatColor territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
-				ActionBarManager.getInstance(MedievalFactions.getInstance()).showPersistentActionBarMessage(player, new TextComponent(territoryAlertColor + title));
+				TerritoryOwnerNotifier.getInstance().sendPlayerTerritoryAlert(player, holder);
 				return;
 			}
 
-			// if chunk is unclaimed
-			if (!ChunkManager.getInstance().isClaimed(player.getLocation().getChunk(), PersistentData.getInstance().getClaimedChunks())) {
-				String title = LocaleManager.getInstance().getText("Wilderness");
-				String territoryAlertColorString = MedievalFactions.getInstance().getConfig().getString("territoryAlertColor");
-				ChatColor territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
-				player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(territoryAlertColor + title));
-				return;
-			}
+			// Otherwise the chunk ist unclaimed
+			TerritoryOwnerNotifier.getInstance().sendPlayerTerritoryAlert(player, null);
 		}
 	}
 

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/MoveHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/MoveHandler.java
@@ -3,11 +3,14 @@ package dansplugins.factionsystem.eventhandlers;
 import dansplugins.factionsystem.DynmapIntegrator;
 import dansplugins.factionsystem.MedievalFactions;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.managers.ActionBarManager;
 import dansplugins.factionsystem.managers.ChunkManager;
 import dansplugins.factionsystem.managers.LocaleManager;
 import dansplugins.factionsystem.objects.ClaimedChunk;
 import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.utils.ColorChecker;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -120,6 +123,18 @@ public class MoveHandler implements Listener {
             territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
         }
 
+
+        // set actionbar
+        if(MedievalFactions.getInstance().getConfig().getBoolean("territoryIndicatorActionbar")) {
+            ActionBarManager actionBar = ActionBarManager.getInstance(MedievalFactions.getInstance());
+
+            if(holder == null) {
+                actionBar.clearPlayerActionBar(player);
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(territoryAlertColor + information));
+            } else {
+                actionBar.showPersistentActionBarMessage(player, new TextComponent(territoryAlertColor + information));
+            }
+        }
 
         // send alert
         if (MedievalFactions.getInstance().getConfig().getBoolean("territoryAlertPopUp")) {

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/MoveHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/MoveHandler.java
@@ -9,6 +9,7 @@ import dansplugins.factionsystem.managers.LocaleManager;
 import dansplugins.factionsystem.objects.ClaimedChunk;
 import dansplugins.factionsystem.objects.Faction;
 import dansplugins.factionsystem.utils.ColorChecker;
+import dansplugins.factionsystem.utils.TerritoryOwnerNotifier;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
@@ -61,15 +62,13 @@ public class MoveHandler implements Listener {
             if (ChunkManager.getInstance().isClaimed(event.getTo().getChunk(), PersistentData.getInstance().getClaimedChunks()) && !ChunkManager.getInstance().isClaimed(event.getFrom().getChunk(), PersistentData.getInstance().getClaimedChunks())) {
                 String factionName = ChunkManager.getInstance().getClaimedChunk(event.getTo().getChunk()).getHolder();
                 Faction holder = PersistentData.getInstance().getFaction(factionName);
-                String title = factionName;
-                sendPlayerTerritoryAlert(event.getPlayer(), title, holder);
+                TerritoryOwnerNotifier.getInstance().sendPlayerTerritoryAlert(player, holder);
                 return;
             }
 
             // if new chunk is unclaimed and old chunk was not
             if (!ChunkManager.getInstance().isClaimed(event.getTo().getChunk(), PersistentData.getInstance().getClaimedChunks()) && ChunkManager.getInstance().isClaimed(event.getFrom().getChunk(), PersistentData.getInstance().getClaimedChunks())) {
-                String title = LocaleManager.getInstance().getText("Wilderness");
-                sendPlayerTerritoryAlert(event.getPlayer(), title, null);
+                TerritoryOwnerNotifier.getInstance().sendPlayerTerritoryAlert(player, null);
                 return;
             }
 
@@ -79,8 +78,7 @@ public class MoveHandler implements Listener {
                 if (!(ChunkManager.getInstance().getClaimedChunk(event.getFrom().getChunk()).getHolder().equalsIgnoreCase(ChunkManager.getInstance().getClaimedChunk(event.getTo().getChunk()).getHolder()))) {
                     String factionName = ChunkManager.getInstance().getClaimedChunk(event.getTo().getChunk()).getHolder();
                     Faction holder = PersistentData.getInstance().getFaction(factionName);
-                    String title = factionName;
-                    sendPlayerTerritoryAlert(event.getPlayer(), title, holder);
+                    TerritoryOwnerNotifier.getInstance().sendPlayerTerritoryAlert(player, holder);
                 }
             }
 
@@ -109,44 +107,6 @@ public class MoveHandler implements Listener {
             }
         }
 
-    }
-
-    public void sendPlayerTerritoryAlert(Player player, String information, Faction holder) {
-        // get color
-        ChatColor territoryAlertColor;
-        if (holder != null) {
-            String territoryAlertColorString = (String) holder.getFlags().getFlag("territoryAlertColor");
-            territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
-        }
-        else {
-            String territoryAlertColorString = MedievalFactions.getInstance().getConfig().getString("territoryAlertColor");
-            territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
-        }
-
-
-        // set actionbar
-        if(MedievalFactions.getInstance().getConfig().getBoolean("territoryIndicatorActionbar")) {
-            ActionBarManager actionBar = ActionBarManager.getInstance(MedievalFactions.getInstance());
-
-            if(holder == null) {
-                actionBar.clearPlayerActionBar(player);
-                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(territoryAlertColor + information));
-            } else {
-                actionBar.showPersistentActionBarMessage(player, new TextComponent(territoryAlertColor + information));
-            }
-        }
-
-        // send alert
-        if (MedievalFactions.getInstance().getConfig().getBoolean("territoryAlertPopUp")) {
-            String subtitle = null;
-            int fadeIn = 10;
-            int stay = 70;
-            int fadeOut = 20;
-            player.sendTitle(territoryAlertColor + information, subtitle, fadeIn, stay, fadeOut);
-        }
-        else {
-            player.sendMessage(territoryAlertColor + information);
-        }
     }
 
 }

--- a/src/main/java/dansplugins/factionsystem/managers/ActionBarManager.java
+++ b/src/main/java/dansplugins/factionsystem/managers/ActionBarManager.java
@@ -1,0 +1,46 @@
+package dansplugins.factionsystem.managers;
+
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class ActionBarManager {
+    private static ActionBarManager instance;
+    private final Map<Player, TextComponent> playerActionBarMessages = new HashMap<Player, TextComponent>();
+
+    private ActionBarManager(Plugin plugin) {
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin,
+                this::sendPlayerActionBarMessages, 5, 20);
+    }
+
+    public static ActionBarManager getInstance(Plugin plugin) {
+        if (instance == null) {
+            instance = new ActionBarManager(plugin);
+        }
+        return instance;
+    }
+
+    public void showPersistentActionBarMessage(Player player, TextComponent message) {
+        playerActionBarMessages.put(player, message);
+        this.sendPlayerActionBarMessage(player, message);
+    }
+
+    public void clearPlayerActionBar(Player player) {
+        playerActionBarMessages.remove(player);
+        this.sendPlayerActionBarMessage(player, new TextComponent(""));
+    }
+
+    private void sendPlayerActionBarMessages () {
+        playerActionBarMessages.forEach(this::sendPlayerActionBarMessage);
+    }
+
+    private void sendPlayerActionBarMessage (Player player, TextComponent message) {
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, message);
+    }
+}

--- a/src/main/java/dansplugins/factionsystem/managers/ConfigManager.java
+++ b/src/main/java/dansplugins/factionsystem/managers/ConfigManager.java
@@ -120,6 +120,9 @@ public class ConfigManager {
         if (!MedievalFactions.getInstance().getConfig().isBoolean("territoryAlertPopUp")) {
             MedievalFactions.getInstance().getConfig().addDefault("territoryAlertPopUp", true);
         }
+        if (!MedievalFactions.getInstance().getConfig().isBoolean("territoryIndicatorActionbar")) {
+            MedievalFactions.getInstance().getConfig().addDefault("territoryIndicatorActionbar", true);
+        }
         if (!MedievalFactions.getInstance().getConfig().isString("territoryAlertColor")) {
             MedievalFactions.getInstance().getConfig().addDefault("territoryAlertColor", "white");
         }

--- a/src/main/java/dansplugins/factionsystem/managers/ConfigManager.java
+++ b/src/main/java/dansplugins/factionsystem/managers/ConfigManager.java
@@ -195,6 +195,7 @@ public class ConfigManager {
                     || option.equalsIgnoreCase("allowAllyInteraction")
                     || option.equalsIgnoreCase("allowVassalageTreeInteraction")
                     || option.equalsIgnoreCase("territoryAlertPopUp")
+                    || option.equalsIgnoreCase("territoryIndicatorActionbar")
                     || option.equalsIgnoreCase("randomFactionAssignment")
                     || option.equalsIgnoreCase("allowNeutrality")
                     || option.equalsIgnoreCase("showPrefixesInFactionChat")) {
@@ -259,6 +260,7 @@ public class ConfigManager {
         MedievalFactions.getInstance().getConfig().addDefault("factionChatColor", "gold");
         MedievalFactions.getInstance().getConfig().addDefault("territoryAlertPopUp", true);
         MedievalFactions.getInstance().getConfig().addDefault("territoryAlertColor", "white");
+        MedievalFactions.getInstance().getConfig().addDefault("territoryIndicatorActionbar", true);
         MedievalFactions.getInstance().getConfig().addDefault("randomFactionAssignment", false);
         MedievalFactions.getInstance().getConfig().addDefault("allowNeutrality", false);
         MedievalFactions.getInstance().getConfig().addDefault("showPrefixesInFactionChat", false);
@@ -304,6 +306,7 @@ public class ConfigManager {
                 + ", factionChatColor: " + MedievalFactions.getInstance().getConfig().getString("factionChatColor")
                 + ", territoryAlertPopUp: " + MedievalFactions.getInstance().getConfig().getBoolean("territoryAlertPopUp")
                 + ", territoryAlertColor: " + MedievalFactions.getInstance().getConfig().getString("territoryAlertColor")
+                + ", territoryIndicatorActionbar: " + MedievalFactions.getInstance().getConfig().getBoolean("territoryIndicatorActionbar")
                 + ", randomFactionAssignment: " + MedievalFactions.getInstance().getConfig().getBoolean("randomFactionAssignment")
                 + ", allowNeutrality: " + MedievalFactions.getInstance().getConfig().getBoolean("allowNeutrality")
                 + ", showPrefixesInFactionChat: " + MedievalFactions.getInstance().getConfig().getBoolean("showPrefixesInFactionChat"));

--- a/src/main/java/dansplugins/factionsystem/utils/TerritoryOwnerNotifier.java
+++ b/src/main/java/dansplugins/factionsystem/utils/TerritoryOwnerNotifier.java
@@ -1,0 +1,67 @@
+package dansplugins.factionsystem.utils;
+
+import dansplugins.factionsystem.MedievalFactions;
+import dansplugins.factionsystem.managers.ActionBarManager;
+import dansplugins.factionsystem.managers.LocaleManager;
+import dansplugins.factionsystem.objects.Faction;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+public class TerritoryOwnerNotifier {
+    private static TerritoryOwnerNotifier instance;
+
+    private TerritoryOwnerNotifier() {
+
+    }
+
+    public static TerritoryOwnerNotifier getInstance() {
+        if (instance == null) instance = new TerritoryOwnerNotifier();
+        return instance;
+    }
+
+    public void sendPlayerTerritoryAlert(Player player, Faction holder) {
+        // get color
+        ChatColor territoryAlertColor;
+        if (holder != null) {
+            String territoryAlertColorString = (String) holder.getFlags().getFlag("territoryAlertColor");
+            territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
+        } else {
+            String territoryAlertColorString = MedievalFactions.getInstance().getConfig().getString("territoryAlertColor");
+            territoryAlertColor = ColorChecker.getInstance().getColorByName(territoryAlertColorString);
+        }
+
+        String title;
+        if(holder != null) {
+            title = holder.getName();
+        } else {
+            title = LocaleManager.getInstance().getText("Wilderness");
+        }
+
+
+        // set actionbar
+        if(MedievalFactions.getInstance().getConfig().getBoolean("territoryIndicatorActionbar")) {
+            ActionBarManager actionBar = ActionBarManager.getInstance(MedievalFactions.getInstance());
+
+            if(holder == null) {
+                actionBar.clearPlayerActionBar(player);
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(territoryAlertColor + title));
+            } else {
+                actionBar.showPersistentActionBarMessage(player, new TextComponent(territoryAlertColor + title));
+            }
+        }
+
+        // send alert
+        if (MedievalFactions.getInstance().getConfig().getBoolean("territoryAlertPopUp")) {
+            int fadeIn = 10;
+            int stay = 70;
+            int fadeOut = 20;
+            player.sendTitle(territoryAlertColor + title, null, fadeIn, stay, fadeOut);
+        }
+        else {
+            player.sendMessage(territoryAlertColor + title);
+        }
+    }
+
+}


### PR DESCRIPTION
First, I want to say thank you for this really cool plugin. I wanted to code something like this for quite a while, but I never found the time. So I am really happy that I found you Plugin.

I added the possibility to display the name of the current land owning faction in the ActionBar. The name of the faction is displayed there as long as the player stays on their land. Wilderness is only displayed for 2 seconds.
This feature can be controlled with the config.yml. I set the default to true, but I won't mind if you change this. 

In the second commit, I made some cleanup to remove duplicate code.
This slightly changed one behavior of the plugin: A player joining the server will now also see the name of the land owning faction as a title (if enabled in the config)

BTW:
I am working on a German translation - But it will take a while with the over 500 lines of text.