### PR TITLE
Reinforced Chest-Handling for LockedBlock mechanisms.

### DIFF
--- a/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/InteractionHandler.java
@@ -127,6 +127,11 @@ public class InteractionHandler implements Listener {
                 public void run() {
                     Block block = player.getWorld().getBlockAt(event.getBlock().getLocation());
 
+                    if (!BlockChecker.getInstance().isChest(block)) {
+                        // There has been 2 seconds since we last confirmed this was a chest, double-checking isn't ever bad :)
+                        return;
+                    }
+
                     InventoryHolder holder = ((Chest) block.getState()).getInventory().getHolder();
                     if (holder instanceof DoubleChest) {
                         // make sure both sides are locked

--- a/src/main/java/dansplugins/factionsystem/utils/BlockChecker.java
+++ b/src/main/java/dansplugins/factionsystem/utils/BlockChecker.java
@@ -3,6 +3,7 @@ package dansplugins.factionsystem.utils;
 import dansplugins.factionsystem.data.PersistentData;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 
 import static org.bukkit.Bukkit.getLogger;
@@ -22,7 +23,7 @@ public class BlockChecker {
     }
 
     public boolean isChest(Block block) {
-        return block.getType() == Material.CHEST;
+        return block.getType() == Material.CHEST && block.getState() instanceof Chest;
     }
 
     public boolean isDoor(Block block) {


### PR DESCRIPTION
Fixes: #1155

2 Seconds had passed since the previous check of BlockType on the Chest, giving a player enough time to mine/replace the Chest itself.

Also provided a more in-depth check to determine if a Block is in-fact a Chest by instance checking its BlockState.