### PR TITLE
#1286 Fixes factionless players being able to access any locked block if they type /mf lock before interacting with it.

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/LockCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/LockCommand.java
@@ -5,6 +5,7 @@
 package dansplugins.factionsystem.commands;
 
 import dansplugins.factionsystem.commands.abs.SubCommand;
+import dansplugins.factionsystem.data.PersistentData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -30,6 +31,7 @@ public class LockCommand extends SubCommand {
     @Override
     public void execute(Player player, String[] args, String key) {
         final String permission = "mf.lock";
+        if (!(playerNotInFaction(player))) return;
         if (!(checkPermissions(player, permission))) return;
         if (args.length >= 1 && safeEquals(args[0], "cancel")) {
             if (ephemeral.getLockingPlayers().remove(player.getUniqueId())) { // Remove them
@@ -52,5 +54,9 @@ public class LockCommand extends SubCommand {
     @Override
     public void execute(CommandSender sender, String[] args, String key) {
 
+    }
+
+    private boolean playerNotInFaction(Player player) {
+        return PersistentData.getInstance().getPlayersFaction(player.getUniqueId()) == null;
     }
 }

--- a/src/main/java/dansplugins/factionsystem/commands/UnlockCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/UnlockCommand.java
@@ -5,6 +5,7 @@
 package dansplugins.factionsystem.commands;
 
 import dansplugins.factionsystem.commands.abs.SubCommand;
+import dansplugins.factionsystem.data.PersistentData;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -28,6 +29,7 @@ public class UnlockCommand extends SubCommand {
     @Override
     public void execute(Player player, String[] args, String key) {
         final String permission = "mf.unlock";
+        if (!(playerNotInFaction(player))) return;
         if (!(checkPermissions(player, permission))) return;
         if (args.length != 0 && args[0].equalsIgnoreCase("cancel")) {
             ephemeral.getUnlockingPlayers().remove(player.getUniqueId());
@@ -55,5 +57,9 @@ public class UnlockCommand extends SubCommand {
     @Override
     public void execute(CommandSender sender, String[] args, String key) {
 
+    }
+
+    private boolean playerNotInFaction(Player player) {
+        return PersistentData.getInstance().getPlayersFaction(player.getUniqueId()) == null;
     }
 }


### PR DESCRIPTION
Added a factionless check to the lock and unlock command
Possible solution to #1286 