### PR TITLE
More checks for factionless

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/LockCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/LockCommand.java
@@ -6,6 +6,7 @@ package dansplugins.factionsystem.commands;
 
 import dansplugins.factionsystem.commands.abs.SubCommand;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.eventhandlers.helper.RelationChecker;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -31,7 +32,7 @@ public class LockCommand extends SubCommand {
     @Override
     public void execute(Player player, String[] args, String key) {
         final String permission = "mf.lock";
-        if (!(playerNotInFaction(player))) return;
+        if (!(RelationChecker.getInstance().playerNotInFaction(player))) return;
         if (!(checkPermissions(player, permission))) return;
         if (args.length >= 1 && safeEquals(args[0], "cancel")) {
             if (ephemeral.getLockingPlayers().remove(player.getUniqueId())) { // Remove them
@@ -54,9 +55,5 @@ public class LockCommand extends SubCommand {
     @Override
     public void execute(CommandSender sender, String[] args, String key) {
 
-    }
-
-    private boolean playerNotInFaction(Player player) {
-        return PersistentData.getInstance().getPlayersFaction(player.getUniqueId()) == null;
     }
 }

--- a/src/main/java/dansplugins/factionsystem/commands/UnlockCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/UnlockCommand.java
@@ -6,6 +6,7 @@ package dansplugins.factionsystem.commands;
 
 import dansplugins.factionsystem.commands.abs.SubCommand;
 import dansplugins.factionsystem.data.PersistentData;
+import dansplugins.factionsystem.eventhandlers.helper.RelationChecker;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -29,7 +30,7 @@ public class UnlockCommand extends SubCommand {
     @Override
     public void execute(Player player, String[] args, String key) {
         final String permission = "mf.unlock";
-        if (!(playerNotInFaction(player))) return;
+        if (!(RelationChecker.getInstance().playerNotInFaction(player))) return;
         if (!(checkPermissions(player, permission))) return;
         if (args.length != 0 && args[0].equalsIgnoreCase("cancel")) {
             ephemeral.getUnlockingPlayers().remove(player.getUniqueId());
@@ -57,9 +58,5 @@ public class UnlockCommand extends SubCommand {
     @Override
     public void execute(CommandSender sender, String[] args, String key) {
 
-    }
-
-    private boolean playerNotInFaction(Player player) {
-        return PersistentData.getInstance().getPlayersFaction(player.getUniqueId()) == null;
     }
 }

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/DamageHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/DamageHandler.java
@@ -157,7 +157,11 @@ public class DamageHandler implements Listener {
     }
 
     private void handleIfFriendlyFire(EntityDamageByEntityEvent event, Player attacker, Player victim) {
-        if (playerNotInFaction(attacker) || playerNotInFaction(victim)) {
+        if (RelationChecker.getInstance().playerNotInFaction(attacker) || RelationChecker.getInstance().playerNotInFaction(victim)) {
+            return;
+        }
+        //i do not know if we also need to check for the inverse victim in faction attack not in faction
+        if (RelationChecker.getInstance().playerInFaction(attacker) || RelationChecker.getInstance().playerNotInFaction(victim)){
             return;
         }
         if (RelationChecker.getInstance().arePlayersInSameFaction(attacker, victim)) {
@@ -176,7 +180,4 @@ public class DamageHandler implements Listener {
         }
     }
 
-    private boolean playerNotInFaction(Player player) {
-        return PersistentData.getInstance().getPlayersFaction(player.getUniqueId()) == null;
-    }
 }

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/helper/RelationChecker.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/helper/RelationChecker.java
@@ -22,6 +22,14 @@ public class RelationChecker {
         return PersistentData.getInstance().isInFaction(player1.getUniqueId()) && PersistentData.getInstance().isInFaction(player2.getUniqueId());
     }
 
+    public boolean playerNotInFaction(Player player) {
+        return PersistentData.getInstance().getPlayersFaction(player.getUniqueId()) == null;
+    }
+
+    public boolean playerInFaction(Player player) {
+        return PersistentData.getInstance().isInFaction(player.getUniqueId());
+    }
+
     public boolean arePlayersInSameFaction(Player player1, Player player2) {
         Pair<Integer, Integer> factionIndices = getFactionIndices(player1, player2);
         int attackersFactionIndex = factionIndices.getLeft();


### PR DESCRIPTION
Fixes #1303 

Changes or features added:
- Moved playerNotInFaction to RelationChecker
- Added playerInFaction to RelationChecker
- Added a check to allow factionless and those in a faction to deal damage