### PR TITLE
Added bypass for the copper golem and the new potion effects. Closes #1900

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -35,6 +35,7 @@ factions:
   allowedMobSpawnReasons:
   - BEEHIVE
   - BREEDING
+  - BUCKET
   - BUILD_IRONGOLEM
   - BUILD_SNOWMAN
   - BUILD_COPPERGOLEM
@@ -59,6 +60,7 @@ factions:
   - SPAWNER
   - SPAWNER_EGG
   - SPELL
+  - TRIAL_SPAWNER
   - VILLAGE_DEFENSE
   laddersPlaceableInEnemyFactionTerritory: true
   maxNameLength: 20


### PR DESCRIPTION
This added the "BUCKET," "BUILD_COPPERGOLEM," "POTION_EFFECT," and "TRIAL_SPAWNER" mob spawn rules to the allowed mob lists for use of the new mechanics added during 1.19 and 1.21. Including but not limited to "Bucket of Tadpole," "Bucket of Axolotl," "Infested" and "Oozing" potion effect, "Copper Golem," and "Trial Spawners." The last one was decided in case a trial chamber was underneath someone's claimed chunks